### PR TITLE
Switch to relative URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "pyclaw"]
 	path = pyclaw
-	url = git://github.com/clawpack/pyclaw
+	url = ../pyclaw
 [submodule "visclaw"]
 	path = visclaw
-	url = git://github.com/clawpack/visclaw
+	url = ../visclaw
 [submodule "clawutil"]
 	path = clawutil
-	url = git://github.com/clawpack/clawutil
+	url = ../clawutil
 [submodule "riemann"]
 	path = riemann
-	url = git://github.com/clawpack/riemann
+	url = ../riemann


### PR DESCRIPTION
This one is a bit of a no-brainer.  Currently the http://github.com/clawpack URLs are hard-coded into the sub-repository paths, making it impossible to maintain proper forks of the clawpack superrepository.  This commit fixes that.

One minor issue that @jedbrown points out is that local recursive clones still don't work.  Hopefully this will be fixed soon in git itself.
