### PR TITLE
Get Travis CI working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - sudo apt-get install -qq gfortran
   - python setup.py install
 script:
-  - cd clawpack/pyclaw
+  - cd pyclaw
   - nosetests
 notifications:
   email: false


### PR DESCRIPTION
Now Travis CI
- properly installs pyclaw (works well)
- runs tests in the `pyclaw` directory (some tests fail, but those are genuine failures)
