### PR TITLE
Remove deprecated pip `--use-mirrors flag`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   - python -c "import numpy; print numpy.__version__"
   - sudo apt-get update -qq
   - sudo apt-get install -qq gfortran liblapack-pic
-  - pip install --use-mirrors matplotlib
-  - pip install --use-mirrors yolk
+  - pip install matplotlib
+  - pip install yolk
   
 install:
   - pip install -e .


### PR DESCRIPTION
This was causing the travis CI tests to fail.