### PR TITLE
Add Python parts of Fortran packages to Python's site-packages

### DIFF
--- a/clawpack/setup.py
+++ b/clawpack/setup.py
@@ -7,6 +7,9 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('visclaw')
     config.add_subpackage('pyclaw')
     config.add_subpackage('petclaw')
+    config.add_subpackage('classic')
+    config.add_subpackage('amrclaw')
+    config.add_subpackage('geoclaw')
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows the Python packages in Classic, AMRClaw, and GeoClaw to be installed in site-packages by default (i.e., unless doing an editable install).  Addresses [CEP 6](https://github.com/clawpack/clawpack/wiki/cep6).