### PR TITLE
change version number in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,9 +91,9 @@ Operating System :: MacOS
 """  
 
 MAJOR               = 5
-MINOR               = 3
-MICRO               = 1
-TYPE                = ''
+MINOR               = 4
+MICRO               = 0
+TYPE                = 'rc-alpha'
 VERSION             = '%d.%d.%d%s' % (MAJOR, MINOR, MICRO, TYPE)
 
 package_path       = os.path.join(os.path.dirname(__file__),'clawpack')


### PR DESCRIPTION
@ketch: We decided to go ahead with this release candidate for testing purposes, but it looks like there are some unresolved issues in PyClaw PRs related to Python 3 support?  So maybe more to do before the actual release?