### PR TITLE
Add forestclaw to top-level clawpack namespace.

### DIFF
--- a/clawpack/__init__.py
+++ b/clawpack/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['clawutil','pyclaw','petclaw','riemann','visclaw']
+__all__ = ['clawutil','pyclaw','petclaw','forestclaw','riemann','visclaw']


### PR DESCRIPTION
I think this will fix the errors we're seeing with https://github.com/clawpack/pyclaw/pull/576.