### PR TITLE
Add failure capture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ script:
   - nosetests
   - cd $CLAW/geoclaw
   - nosetests
+
+after_failure:
+ - for failed_test_path in *_output ; do cat $failed_test_path/run_output.txt ; cat $failed_test_path/error_output.txt ; done
   
 notifications:
   email: false


### PR DESCRIPTION
Adds the lines so that any compiled code test failures will dump out the relevant error output.