### PR TITLE
Avoid using symlinks when installing clawpack.

### DIFF
--- a/.f2py_f2cmap
+++ b/.f2py_f2cmap
@@ -1,0 +1,1 @@
+dict(real = dict(dp="double"))

--- a/clawpack/setup.py
+++ b/clawpack/setup.py
@@ -2,15 +2,15 @@
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('clawpack',parent_package,top_path)
-    config.add_subpackage('clawutil')
-    config.add_subpackage('riemann')
-    config.add_subpackage('visclaw')
-    config.add_subpackage('pyclaw')
-    config.add_subpackage('petclaw')
-    config.add_subpackage('forestclaw')
-    config.add_subpackage('classic')
-    config.add_subpackage('amrclaw')
-    config.add_subpackage('geoclaw')
+    config.add_subpackage('clawutil',  subpackage_path='clawutil/src/python/clawutil')
+    config.add_subpackage('riemann', subpackage_path='riemann/src')
+    config.add_subpackage('visclaw',  subpackage_path='visclaw/src/python/visclaw')
+    config.add_subpackage('pyclaw', subpackage_path='pyclaw/src/pyclaw')
+    config.add_subpackage('petclaw', subpackage_path='pyclaw/src/petclaw')
+    config.add_subpackage('forestclaw', subpackage_path='pyclaw/src/forestclaw')
+    config.add_subpackage('classic',  subpackage_path='classic/src/python/classic')
+    config.add_subpackage('amrclaw',  subpackage_path='amrclaw/src/python/amrclaw')
+    config.add_subpackage('geoclaw',  subpackage_path='geoclaw/src/python/geoclaw')
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
This finally gets rid of the hacky symlink-based install process that we have had for several years.  It turned out to be surprisingly easy.  Many thanks to @dalcinl for his immense help in getting this set up.

Instead of making symlinks, we simply specify the path to each subpackage in the calls to distutils.