### PR TITLE
update version number to 5.6.1

### DIFF
--- a/clawpack/__init__.py
+++ b/clawpack/__init__.py
@@ -21,4 +21,4 @@ __path__.extend(_sdir for _sdir in _path
                 if _os.path.isdir(_sdir))
 del _root, _path
 
-__version__ = '5.6.0'
+__version__ = '5.6.1'   # must also be changed in setup.py

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,10 @@ Operating System :: MacOS
 
 """
 
+# version must also be changed in clawpack/__init__.py
 MAJOR               = 5
 MINOR               = 6
-MICRO               = 0
+MICRO               = 1
 TYPE                = ''
 VERSION             = '%d.%d.%d%s' % (MAJOR, MINOR, MICRO, TYPE)
 


### PR DESCRIPTION
Note this has to be changed two places, so I added some comments.

I considered having `__init__.py` read it from `clawpack/version.py`, a file created when running `setup.py`, but that wouldn't work if someone simply sets `PYTHONPATH` rather than pip installing a new version, since `clawpack/version.py` won't exist in that case.