### PR TITLE
improved clawpack/__init__.py so no symbolic links needed

### DIFF
--- a/clawpack/__init__.py
+++ b/clawpack/__init__.py
@@ -1,1 +1,25 @@
-__all__ = ['clawutil','pyclaw','petclaw','forestclaw','riemann','visclaw']
+import os as _os
+
+_subpackages = {
+    'clawutil':   'clawutil/src/python',
+    'riemann':    'riemann',
+    'visclaw':    'visclaw/src/python',
+    'pyclaw':     'pyclaw/src',
+    'petclaw':    'pyclaw/src',
+    'forestclaw': 'pyclaw/src',
+    'classic':    'classic/src/python',
+    'amrclaw':    'amrclaw/src/python',
+    'geoclaw':    'geoclaw/src/python',
+}
+
+__all__ = list(_subpackages.keys())
+
+_root = _os.path.dirname(__path__[0])
+_path = (_os.path.join(_root, *_sdir.split('/'))
+         for _sdir in set(_subpackages.values()))
+__path__.extend(_sdir for _sdir in _path
+                if _os.path.isdir(_sdir))
+del _root, _path
+
+__version__ = 'GPU'   # must also be changed in setup.py
+


### PR DESCRIPTION
This avoids need for symbolic links in clawpack/clawpack so that import statements work without needing to "install" using setup.py, as in more recent versions of the master branch.