### PR TITLE
Bump version number to 5.9.1 in clawpack/setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ Operating System :: MacOS
 # version must also be changed in clawpack/__init__.py
 MAJOR               = 5
 MINOR               = 9
-MICRO               = 0
+MICRO               = 1
 TYPE                = ''
 VERSION             = '%d.%d.%d%s' % (MAJOR, MINOR, MICRO, TYPE)
 


### PR DESCRIPTION
I forgot to do this before the release.