### PR TITLE
Fix some minor issues and warnings in the Meson build config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,11 @@ add_project_arguments(
   language : 'c',
 )
 
+add_project_link_arguments(
+  cc.get_supported_link_arguments('-Wl,-no_compact_unwind'),
+  language: 'c',
+)
+
 subpackages = {
   'clawutil':   'clawutil/src/python',
   'pyclaw':     'pyclaw/src',

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ incdir_f2py = run_command(py,
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)
 
+f2py_version = run_command([py, '-m', 'numpy.f2py', '-v'], check: true).stdout().strip()
+message(f'f2py version: @f2py_version@')
+
 f2py = [
   py, '-m', 'numpy.f2py',
   '--lower', '--quiet',

--- a/meson.build
+++ b/meson.build
@@ -1,18 +1,14 @@
 project(
   'clawpack',
   'c', 'fortran',
-  version: run_command(
-    find_program('python3'),
-    files('metadata.py'), 'version',
-    check: true,
-  ).stdout().strip(),
+  version: run_command([find_program('metadata.py'), 'version'], check: true).stdout().strip(),
   license: 'BSD-3-Clause',
   license_files: ['LICENSE'],
   meson_version: '>=1.1.0',
 )
 
 fs = import('fs')
-py = import('python').find_installation('python3', pure: false)
+py = import('python').find_installation(pure: false)
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ inc_np = include_directories(incdir_numpy, incdir_f2py)
 
 f2py = [
   py, '-m', 'numpy.f2py',
-  '--lower',
+  '--lower', '--quiet',
   '--build-dir', '@OUTDIR@',
   '@INPUT@',
   '-m', # <extension-name>
@@ -45,6 +45,7 @@ add_project_arguments(
 add_project_arguments(
 #  '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION',
   cc.get_supported_arguments(
+    '-Wno-misleading-indentation',
     '-Wno-unused-but-set-variable',
   ),
   language : 'c',

--- a/metadata.py
+++ b/metadata.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import re
 import os
 import sys


### PR DESCRIPTION
Triggered by gh-249. I can't reproduce that issue, but this PR should at least help make such issues easier to diagnose. Changes:
- don't explicitly call `python3`, because that may not work on Windows or when `python3` is not the interpreter that clawpack is being built for
- add `--quiet` to the `f2py` calls to remove a lot of noise in the build logs (not 100% quiet, look like something needs fixing in f2py as well)
- add `-Wl,-no_compact_unwind` to avoid a lot more build warnings (see the commit message for details)
- add the `f2py` version number to the build log (helps diagnose build-related bug reports)