### PR TITLE
Add NumFOCUS CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,75 +1,42 @@
-# Clawpack Community Contributor Covenant Code of Conduct
+# Clawpack Community NumFOCUS Code of Conduct
 
-## Our Pledge
+As a [NumFOCUS](https://numfocus.org) affiliated project we have elected to
+adopt the NumFOCUS code of conduct.
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+## The Short Version
 
-## Our Standards
+NumFOCUS and the Clawpack community is dedicated to providing a
+harassment-free community for everyone, regardless of gender, sexual
+orientation, gender identity and expression, disability, physical appearance,
+body size, race, or religion. We do not tolerate harassment of community
+members in any form.
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Be kind to others. Do not insult or put down others. Behave professionally.
+Remember that harassment and sexist, racist, or exclusionary jokes are not
+appropriate for NumFOCUS or Clawpack.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+All communication should be appropriate for a professional audience including
+people of many different backgrounds. Sexual language and imagery is not
+appropriate.
 
-Examples of unacceptable behavior by participants include:
+Thank you for helping make this a welcoming, friendly community for all.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+## Long Version
 
-## Our Responsibilities
+You can find the long version of the Code of Conduct on the NumFOCUS website 
+https://numfocus.org/code-of-conduct.
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+## How To Report
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+If you feel that the Code of Conduct has been violated, feel free to submit a
+report, by using the form: [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org). 
 
-## Scope
+## Who Will Receive Your Report
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+Your report will be received and handled by NumFOCUS Code of Conduct Working
+Group; trained, and experienced contributors with diverse backgrounds. The
+group is making decisions independently from the Clawpack project, PyData,
+NumFOCUS or any other organization. 
 
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting one of the project team,
-either [David Ketcheson](david.ketcheson@kaust.edu.sa), [Randy
-LeVeque](rjl@uw.edu), or [Kyle Mandli](kyle.mandli@columbia.edu). All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-
-[homepage]: https://www.contributor-covenant.org
+You can learn more about the current group members, as well as the reporting
+procedure [HERE](https://numfocus.org/code-of-conduct).


### PR DESCRIPTION
This updates the code of conduct to match the proposed NumFOCUS code of conduct document.  This mostly matches what is now proposed in the clawpack/doc repository.